### PR TITLE
Fixed Speed Calculation (Poles -> Pole Pairs)

### DIFF
--- a/display/res/speed_box.lisp
+++ b/display/res/speed_box.lisp
@@ -7,7 +7,7 @@
 @const-start
 (defun speed_cal(){
     (if (and (not-eq poles_config 0) (not-eq pulley_config 0))
-        (setq speed_val (*(* (/ (/ (abs rpm) poles_config) pulley_config) wheel_diam_config 0.18845)))
+        (setq speed_val (*(* (/ (/ (abs rpm) (/ poles_config 2)) pulley_config) wheel_diam_config 0.18845)))
         (setq speed_val 0.0)
     )
 


### PR DESCRIPTION
The Poles setting implies total poles, but was used as Pole Pairs in the speed calculation. Fixed such that the set total poles is divided by 2 in the calculation. Before the fix, the speed was reading as half.