### PR TITLE
Fix & Clean-up Trip + Current Readings

### DIFF
--- a/display/res/amps_box.lisp
+++ b/display/res/amps_box.lisp
@@ -1,9 +1,7 @@
 @const-start
 (defun write_amps (amp px py){
        (def amp_box (img-buffer 'indexed2 55 14))
-       (setvar 'amp (to-i (* 10 amp)))
-       (txt-block-l amp_box 1 0 0 font_9x14 (str-from-n amp "%04dA"))
-       (txt-block-c amp_box 1 28 0 font_9x14 ".")
+       (txt-block-l amp_box 1 0 0 font_9x14 (str-from-n amp "%3.0fA")) ;; Could set to %1.0fA or %2.0fA if we want to be more left aligned more often
        (disp-render amp_box px py '(0 0xFFFFFF))
 })
 @const-end

--- a/display/res/trip_box.lisp
+++ b/display/res/trip_box.lisp
@@ -3,17 +3,16 @@
 
        (def trip_box (img-buffer 'indexed2 64 14))
 
-       (if (= km_mi 0){
-            (setq dist (* dist 0.6213))
-            (setq dist (to-i dist))
-            (txt-block-l trip_box 1 0 0 font_9x14 (str-from-n dist "%05dmi"))
-       }
-       {
-            (setq dist (to-i dist))
-            (txt-block-l trip_box 1 0 0 font_9x14 (str-from-n dist "%05dkm"))
-       })
+       (setq dist (* dist 0.00001)) ;; Not sure why dist is scaled down so much? This fixes scale.
 
-       (txt-block-l trip_box 1 14 0 font_9x14 ".")
+       (if (= km_mi 0)
+            (setq dist (* dist 0.6213)))
+       (txt-block-l trip_box 1 0 0 font_9x14 
+           (str-from-n dist 
+               (if (= km_mi 0)
+                   (if (> dist 999.9) "999.9mi" "%5.1fmi")
+                   (if (> dist 999.9) "999.9km" "%5.1fkm"))))
+
        (disp-render trip_box px py '(0 0xFFFFFF))
 })
 @const-end


### PR DESCRIPTION
- Scale of Trip Distance fixed (may be incorrect elsewhere? Worth investigating)
- Formatting of Distance fixed to be more legible (X.X miles, no leading zeros, more space between sides of decimal)
- Formatting of Amps fixed to be more legible (No leading zeros, integers only)