### PR TITLE
Speed Reading Revamp

### DIFF
--- a/display/res/mode_box.lisp
+++ b/display/res/mode_box.lisp
@@ -1,29 +1,29 @@
 @const-start
 (defun write_mode (mode px py){
 
-    (def mode_box (img-buffer 'indexed16 28 26))
+    (def mode_box (img-buffer 'indexed16 24 26))
     (if (= mode 0)
         (progn
-        (img-rectangle mode_box 0 0 28 26 1 '(filled) '(rounded 2) )
-        (txt-block-c mode_box 0 14 13 font_13x16_b "L")
+        (img-rectangle mode_box 0 0 24 26 1 '(filled) '(rounded 2) )
+        (txt-block-c mode_box 0 12 13 font_13x16_b "L")
         )
     )
     (if (= mode 1)
         (progn
-        (img-rectangle mode_box 0 0 28 26 2 '(filled) '(rounded 2) )
-        (txt-block-c mode_box 0 14 13 font_13x16_b "M")
+        (img-rectangle mode_box 0 0 24 26 2 '(filled) '(rounded 2) )
+        (txt-block-c mode_box 0 12 13 font_13x16_b "M")
         )
     )
     (if (= mode 2)
         (progn
-        (img-rectangle mode_box 0 0 28 26 3 '(filled) '(rounded 2) )
-        (txt-block-c mode_box 0 14 13 font_13x16_b "H")
+        (img-rectangle mode_box 0 0 24 26 3 '(filled) '(rounded 2) )
+        (txt-block-c mode_box 0 12 13 font_13x16_b "H")
         )
     )
     (if (= mode 3)
         (progn
-        (img-rectangle mode_box 0 0 28 26 4 '(filled) '(rounded 2) )
-        (txt-block-c mode_box 0 14 13 font_13x16_b "S")
+        (img-rectangle mode_box 0 0 24 26 4 '(filled) '(rounded 2) )
+        (txt-block-c mode_box 0 12 13 font_13x16_b "S")
         )
     )
     (disp-render mode_box px py '(0 0x00FF00 0xFFFF00  0xFFA000 0xFF0000))

--- a/display/res/speed_box.lisp
+++ b/display/res/speed_box.lisp
@@ -14,18 +14,38 @@
 })
 
 (defun write-speed (speed m_k px py color){
-
-    (def speed_box (img-buffer 'indexed4 60 30))
-    (setq speed (to-i (* 10 speed)))
-    (txt-block-l speed_box color 0 0 font_20x30 (str-from-n speed "%03d"))
-    (txt-block-c speed_box color 40 0 font_20x30 ".")
+    (def speed_box (img-buffer 'indexed4 65 30))
+    
+    ; Cap speed at 999.9
+    (if (>= speed 1000.0)
+        (setq speed 999.9)
+    )
+    
+    (if (>= speed 100.0)
+        (txt-block-l speed_box color 2 0 font_20x30 
+            (str-from-n (to-i speed) "%3d"))
+        (progn
+            ; Write whole number part - right aligned
+            (txt-block-l speed_box color 
+                (if (>= speed 10.0) 0 10) 0 font_20x30
+                (str-from-n (to-i speed) 
+                    (if (>= speed 10.0) "%2d" "%1d")))
+            ; Write decimal point
+            (txt-block-l speed_box color 
+                (if (>= speed 10.0) 34 24) 0 font_20x30 ".") ; Adjust decimal point position
+            ; Write fraction
+            (txt-block-l speed_box color 
+                (if (>= speed 10.0) 47 37) 0 font_20x30 ; Adjust fraction position
+                (str-from-n (to-i (* (- speed (to-i speed)) 10)) "%1d"))
+        )
+    )
+    
     (disp-render speed_box px py '(0x00000 0xFFFFFF 0x00FF00 0xFF0000))
     (def unit_box (img-buffer 'indexed2 27 17))
     (if (= m_k 0)
             (txt-block-l unit_box 1 0 0 font_9x14 "mph")
             (txt-block-l unit_box 1 0 0 font_9x14 "kph")
     )
-    (disp-render unit_box (+ px 63) (+ py 15) '(0x00000 0xFFFFFF))
-
+    (disp-render unit_box (+ px 68) (+ py 15) '(0x00000 0xFFFFFF))
 })
 @const-end

--- a/display/screens/main_screen.lisp
+++ b/display/screens/main_screen.lisp
@@ -22,7 +22,7 @@
          (write_trip distance 1 (+ x_offset 63) (+ y_offset 50))
     }
     {
-        (write-speed (* (speed_cal) 0.621) 0 (+ x_offset 33) (+ y_offset 19) speed_color)  ; miles
+        (write-speed (* (speed_cal) 0.621) 0 (+ x_offset 28) (+ y_offset 19) speed_color)  ; miles
         (write_trip distance 0 (+ x_offset 63) (+ y_offset 50))
     })
 })


### PR DESCRIPTION
Re-did formatting and layout to make the speed reading much more legible.
- Made fraction digits spaced further from whole digits
- Got rid of leading 0's, center text instead when < 10
- Remove decimal beyond 100, and handle max of 999
- Adjust mode_box to accommodate new layout

TO-DO: Add option to disable fraction (only show whole number, round down)